### PR TITLE
SLING-7365 for unsupported java version fall back to Java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,10 +88,11 @@
             <version>1.3.0</version>
             <scope>provided</scope>
         </dependency>
+        <!-- the correct GAV is referenced in https://bugs.eclipse.org/bugs/show_bug.cgi?id=499019#c19 -->
         <dependency>
-            <groupId>org.eclipse.jdt.core.compiler</groupId>
+            <groupId>org.eclipse.jdt</groupId>
             <artifactId>ecj</artifactId>
-            <version>4.6.1</version>
+            <version>3.13.100</version> <!-- this is the version shipped in Oxygen .2 -->
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/org/apache/sling/commons/compiler/impl/EclipseJavaCompiler.java
+++ b/src/main/java/org/apache/sling/commons/compiler/impl/EclipseJavaCompiler.java
@@ -26,6 +26,8 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.apache.sling.commons.classloader.ClassLoaderWriter;
 import org.apache.sling.commons.compiler.CompilationResult;
@@ -70,6 +72,8 @@ public class EclipseJavaCompiler implements JavaCompiler {
 
     /** the static policy. */
     private final IErrorHandlingPolicy policy = DefaultErrorHandlingPolicies.exitAfterAllProblems();
+    
+    private final Set<String> warningEmittedForUnsupportedJavaVersion = new CopyOnWriteArraySet<>();
 
     /**
      * Get the classloader for the compilation.
@@ -235,7 +239,10 @@ public class EclipseJavaCompiler implements JavaCompiler {
     private String adjustJavaVersion(String javaVersion) {
         // use latest supported version (Java 9) in case the given java version is not supported by ECJ yet
         if (CompilerOptions.versionToJdkLevel(javaVersion) == 0) {
-            logger.warn("Using unsupported java version '{}', assuming latest supported version '{}'", javaVersion, CompilerOptions.VERSION_9);
+            // only log once per invalid javaVersion
+            if (!warningEmittedForUnsupportedJavaVersion.contains(javaVersion) && warningEmittedForUnsupportedJavaVersion.add(javaVersion)) {
+                logger.warn("Using unsupported java version '{}', assuming latest supported version '{}'", javaVersion, CompilerOptions.VERSION_9);
+            }
             return CompilerOptions.VERSION_9;
         }
         return javaVersion;

--- a/src/main/java/org/apache/sling/commons/compiler/impl/EclipseJavaCompiler.java
+++ b/src/main/java/org/apache/sling/commons/compiler/impl/EclipseJavaCompiler.java
@@ -233,9 +233,12 @@ public class EclipseJavaCompiler implements JavaCompiler {
     }
 
     private String adjustJavaVersion(String javaVersion) {
-
-        // ECJ 4.6.1 expects Java version 1.9, not 9
-        return "9".equals(javaVersion) ? "1.9" : javaVersion;
+        // use latest supported version (Java 9) in case the given java version is not supported by ECJ yet
+        if (CompilerOptions.versionToJdkLevel(javaVersion) == 0) {
+            logger.warn("Using unsupported java version '{}', assuming latest supported version '{}'", javaVersion, CompilerOptions.VERSION_9);
+            return CompilerOptions.VERSION_9;
+        }
+        return javaVersion;
     }
 
     //--------------------------------------------------------< inner classes >


### PR DESCRIPTION
also upgrade to the latest Eclipse Java Compiler (with the right GAV)
shipped with Oxygen .2